### PR TITLE
Make the tests pass with tidylib 5

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -48,20 +48,20 @@ class TestDocs1(unittest.TestCase):
 
     def test_alt_added_to_img(self):
         h = "<img src='foo'>"
-        expected = DOC % '''<img src='foo' alt="">'''
-        doc, err = tidy_document(h)
+        expected = DOC % '''<img src='foo' alt="bar">'''
+        doc, err = tidy_document(h, {'alt-text': 'bar'})
         self.assertEqual(doc, expected)
 
     def test_entity_preserved_using_bytes(self):
         h = b"&eacute;"
         expected = (DOC % "&eacute;").encode('utf-8')
-        doc, err = tidy_document(h)
+        doc, err = tidy_document(h, {'preserve-entities': 1})
         self.assertEqual(doc, expected)
 
     def test_numeric_entities_using_bytes(self):
         h = b"&eacute;"
         expected = (DOC % "&#233;").encode('utf-8')
-        doc, err = tidy_document(h, {'numeric-entities': 1})
+        doc, err = tidy_document(h, {'numeric-entities': 1, 'output-encoding': 'ascii'})
         self.assertEqual(doc, expected)
 
     def test_non_ascii_preserved(self):

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -36,20 +36,20 @@ class TestFrags1(unittest.TestCase):
 
     def test_alt_added_to_img(self):
         h = "<img src='foo'>"
-        expected = '''<img src='foo' alt="">'''
-        doc, err = tidy_fragment(h)
+        expected = '''<img src='foo' alt="bar">'''
+        doc, err = tidy_fragment(h, {'alt-text': 'bar'})
         self.assertEqual(doc, expected)
 
     def test_entity_preserved_using_bytes(self):
         h = b"&eacute;"
         expected = b"&eacute;"
-        doc, err = tidy_fragment(h)
+        doc, err = tidy_fragment(h, {'preserve-entities': 1})
         self.assertEqual(doc, expected)
 
     def test_numeric_entities_using_bytes(self):
         h = b"&eacute;"
         expected = b"&#233;"
-        doc, err = tidy_fragment(h, {'numeric-entities': 1})
+        doc, err = tidy_fragment(h, {'numeric-entities': 1, 'output-encoding': 'ascii'})
         self.assertEqual(doc, expected)
 
     def test_non_ascii_preserved(self):


### PR DESCRIPTION
Fixes #13. See https://github.com/countergram/pytidylib/issues/13#issuecomment-242939600 for details.

The tests still pass with tidylib 0.99.