### PR TITLE
Add libtidy.so.5 to default libs

### DIFF
--- a/tidylib/tidy.py
+++ b/tidylib/tidy.py
@@ -29,8 +29,8 @@ from .sink import create_sink, destroy_sink
 __all__ = ['Tidy', 'PersistentTidy']
 
 # Default search order for library names if nothing is passed in
-LIB_NAMES = ['libtidy', 'libtidy.so', 'libtidy-0.99.so.0', 'cygtidy-0-99-0',
-             'tidylib', 'libtidy.dylib', 'tidy']
+LIB_NAMES = ['libtidy', 'libtidy.so', 'libtidy.so.5', 'libtidy-0.99.so.0',
+             'cygtidy-0-99-0', 'tidylib', 'libtidy.dylib', 'tidy']
 
 # Error code from library
 ENOMEM = -12


### PR DESCRIPTION
I'm adding an extra fallback name here.  

Might not be relevant, but for context, the motivation was getting this to work on Heroku (using their [apt buildpacks](https://github.com/heroku/heroku-buildpack-apt)).  I noticed that on Heroku, the function in [this line](https://github.com/countergram/pytidylib/blob/d43ea597f6dcf0e09d50c5083a17c97fa137bc13/tidylib/tidy.py#L87) returns None.  So it could be something to do with Heroku (bit out of my depth there), but I thought regardless, this is a nice fallback to add.  What do you think?